### PR TITLE
Require clients to validate the issuer identifier

### DIFF
--- a/draft-wuertele-oauth-security-topics-update.md
+++ b/draft-wuertele-oauth-security-topics-update.md
@@ -285,16 +285,20 @@ for each authorization server.
 
 #### Authorization Server Issuer Identifier
 
-Clients MUST use the authorization server's issuer identifier (as
-defined in {{!RFC8414}}) as the sole audience value in client
-assertions.
+Clients MUST use the authorization server's issuer identifier as defined
+in {{!RFC8414}}/{{OpenID.Discovery}} as the sole audience value in
+client assertions. Clients they MUST retrieve and validate this value as
+described in {{Section 3.3 of !RFC8414}}/Section 4.3 of
+{{OpenID.Discovery}}.
 
 For `jwt-bearer` client assertions as defined by {{RFC7523}}, this
 mechanism is also described in {{OAUTH-7523bis}}.
 
 Note that "issuer identifier" here does not refer to the term "issuer"
 as defined in {{Section 4.4 of RFC9700}}, but to the issuer identifier
-as used in {{!RFC8414}} and {{OpenID.Discovery}}.
+defined in {{!RFC8414}} and {{OpenID.Discovery}}. In particular, the
+issuer identifier is not just "an abstract identifier for the
+combination the authorization endpoint and token endpoint".
 
 #### Exact Target Endpoint URI
 

--- a/draft-wuertele-oauth-security-topics-update.md
+++ b/draft-wuertele-oauth-security-topics-update.md
@@ -287,7 +287,7 @@ for each authorization server.
 
 Clients MUST use the authorization server's issuer identifier as defined
 in {{!RFC8414}}/{{OpenID.Discovery}} as the sole audience value in
-client assertions. Clients they MUST retrieve and validate this value as
+client assertions. Clients MUST retrieve and validate this value as
 described in {{Section 3.3 of !RFC8414}}/Section 4.3 of
 {{OpenID.Discovery}}.
 


### PR DESCRIPTION
Also, better describe the difference to the "issuer" in RFC 9700.

Fixes #10