### PR TITLE
Clarify that same/distinct redirection URI is not a precondition of COAT

### DIFF
--- a/draft-ietf-oauth-security-topics-update.md
+++ b/draft-ietf-oauth-security-topics-update.md
@@ -477,7 +477,6 @@ Preconditions: It is assumed that
 
 * the implicit or authorization code grant is used with multiple OAuth connection contexts, of which one combination is considered "honest" (H-Tool using H-AuthProvider with H-AS) and one is operated by the attacker (A-Tool using A-AuthProvider with A-AS), and
 * the client stores the connection context chosen by the user in a session bound to the user's browser, and
-* the client issues redirection URIs which do not depend on all variables in the connection context (e.g., auth provider, tool, tenant), and
 * the authorization servers properly check the redirection URI by enforcing exact redirection URI matching (otherwise, see Cross Social-Network Request Forgery in {{research.jcs_14}} for details).
 
 In the following, it is further assumed that the client is registered with H-AS (URI: `https://honest.as.example`, client ID: `7ZGZldHQ`) and with A-AS (URI: `https://attacker.example`, client ID: `666RVZJTA`). Assume that the client issues the redirection URI `https://client.com/honest-cb` for the honest tool and `https://client.com/attack-cb` for the attacker's. URLs shown in the following example are shortened for presentation to include only parameters relevant to the attack.


### PR DESCRIPTION
Resolves #40 .

COAT can happen regardless of the uniqueness of `redirect_uri`. Even with distinct redirect_uri enforced, a client failing to match the distinct element with the one in session is still vulnerable. Therefore remove the precondition.

Section 4.4 of RFC9700 failed to point this out and assumes "the client uses the same redirection URI for each authorization server" as mix-up attack precondition, which is untrue.