### PR TITLE
Improve description of Audience Injection attacks and defenses

### DIFF
--- a/draft-ietf-oauth-security-topics-update.md
+++ b/draft-ietf-oauth-security-topics-update.md
@@ -319,25 +319,34 @@ by the client and contains, among others, the following claims:
 "aud": "https://honest.com/token"
 ~~~
 
-Due to the malicious use of H-AS' token endpoint in A-AS'
-authorization server metadata, the `aud` claim contains H-AS' token
-endpoint.  Recall that both A-AS and H-AS registered the client with
-client ID `cid`, and that the client uses the same key pair for
-authentication at both authorization servers.  Hence, this client
-assertion is a valid authentication credential for the client at
-H-AS.
+Due to the malicious use of H-AS' token endpoint in A-AS' authorization
+server metadata, the `aud` claim contains H-AS' token endpoint (see
+{{TokenEPasAud}}).  Recall that both A-AS and H-AS registered the
+client with client ID `cid`, and that the client uses the same key pair
+for authentication at both authorization servers.  Hence, this client
+assertion is a valid authentication credential for the client at H-AS.
+
+Once the attacker obtained such a client assertion, it can impersonate
+the client towards H-AS.  This enables multiple attacks.  For example,
+the attacker may obtain access tokens via a client credentials grant.
+Another example is the attacker initiating a regular authorization code
+grant where a victim user grants access to the honest client at H-AS,
+but the access token ends up with the attacker (since the attacker fully
+impersonates the client in this case, mechanisms like DPoP {{?RFC9449}}
+cannot protect against the attack).
+
+Further attack scenarios and additional details are given in
+{{research.ust}}.
+
+#### Token Endpoint as Client Assertion Audience {#TokenEPasAud}
 
 The use of the token endpoint to identify the authorization server as a
-client assertion's audience even for client assertions that are not sent
-to the token endpoint is encouraged, or at least allowed by many
+client assertion's audience (even for client assertions that are not sent
+to the token endpoint) is encouraged, or at least allowed by many
 standards, including {{RFC7521}}, {{RFC7522}}, {{RFC7523}}, {{RFC9126}},
 {{OpenID.Core}}, {{OpenID.CIBA}}, and all standards referencing the IANA
 registry for OAuth Token Endpoint Authentication Methods for available
 client authentication methods.
-
-As described in {{research.ust}}, the attacker can then utilize the
-obtained client authentication assertion to impersonate the client and,
-for example, obtain access tokens.
 
 #### Endpoints Requiring Client Authentication {#AudienceInjectionEndpoints}
 

--- a/draft-ietf-oauth-security-topics-update.md
+++ b/draft-ietf-oauth-security-topics-update.md
@@ -97,6 +97,23 @@ informative:
     date: September 2021
     target: https://openid.net/specs/openid-client-initiated-backchannel-authentication-core-1_0.html
     title: OpenID Connect Client-Initiated Backchannel Authentication Flow - Core 1.0
+  OpenID.Federation:
+    author:
+    - ins: R. Hedberg
+      name: Roland Hedberg
+    - ins: M. Jones
+      name: Michael B. Jones
+    - ins: A. Solberg
+      name: Andreas Åkre Solberg
+    - ins: J. Bradley
+      name: John Bradley
+    - ins: G. De Marco
+      name: Giuseppe De Marco
+    - ins: V. Dzhuvinov
+      name: Vladimir Dzhuvinov
+    date: February 2026
+    target: https://openid.net/specs/openid-federation-1_0-final.html
+    title: OpenID Federation 1.0
   research.ust:
     author:
     - ins: P. Hosseyni
@@ -398,7 +415,8 @@ Clients that interact with more than one authorization server and
 authenticate with signature-based client authentication methods MUST
 employ one of the following countermeasures, unless audience injection
 attacks are mitigated by other means, such as using fresh key material
-for each authorization server.
+for each authorization server.  It is RECOMMENDED to prefer the
+countermeasure described in {{AudienceInjectionCountermeasuresASissuer}}.
 
 The countermeasures described below mandate the use of single audience
 value (as opposed to multiple audiences in an array).  This is because
@@ -408,20 +426,6 @@ identifies with only one of the values in such an array.  Since the
 countermeasures rely on the client using an unambiguous audience value,
 there is no value in including additional ones (that would need to be
 unambiguous as well).
-
-Note that the countermeasures described in
-{{AudienceInjectionCountermeasuresASissuer}} and
-{{AudienceInjectionCountermeasuresTargetEP}} do not imply any normative
-changes to the authorization server: {{Section 4.1.3 of ?RFC7519}}
-requires the authorization server to only accept a JWT if the
-authorization server can identify itself with (at least one of the
-elements in) the JWT's audience value. Authentication JWTs produced by a
-client implementing one of these countermeasures meet this condition.
-Of course, an authorization server MAY still decide to only accept its
-issuer identifier ({{AudienceInjectionCountermeasuresASissuer}}) or the
-endpoint that received the JWT
-({{AudienceInjectionCountermeasuresTargetEP}}) as an audience value, for
-example, to force its clients to adopt the respective countermeasure.
 
 #### Authorization Server Issuer Identifier {#AudienceInjectionCountermeasuresASissuer}
 
@@ -449,6 +453,38 @@ sent as that client assertion's sole audience value.
 This countermeasure can be used for authorization servers that do not
 use authorization server metadata {{!RFC8414}} or OpenID Discovery
 {{OpenID.Discovery}}.
+
+
+#### Implementation Considerations
+
+Technically, the countermeasures described in
+{{AudienceInjectionCountermeasuresASissuer}} and
+{{AudienceInjectionCountermeasuresTargetEP}} do not imply any normative
+changes to the authorization server: {{Section 4.1.3 of ?RFC7519}}
+requires the authorization server to only accept a (client assertion) JWT if the
+authorization server can identify itself with (at least one of the
+elements in) the JWT's audience value. Client assertions produced by a
+client implementing one of these countermeasures meet this condition.
+
+However, some existing authorization server implementations only accept
+their token endpoint as the audience value in client assertions,
+including for authentication at endpoints other than the token endpoint.
+Clients interacting with such authorization servers MUST employ
+alternative countermeasures.  In this case, clients SHOULD use one of
+the following countermeasures, in decreasing order of preference:
+
+  1. Use distinct authentication key material with each authorization server.
+  2. Ensure the use of unique client identifiers across all authorization servers (note that this might not be feasible in some ecosystems, for example, in connection with OpenID Federation {{OpenID.Federation}}).
+  3. Ensure uniqueness of all (client identifier, token endpoint) pairs and use the token endpoint as the sole audience value in all client assertions.
+
+While an authorization server that already accepts (among other values)
+its issuer identifier or the exact endpoint as client assertion audience
+values does not need to change anything, such an authorization server
+MAY still decide to restrict acceptance to its issuer identifier
+({{AudienceInjectionCountermeasuresASissuer}}) or the endpoint that
+received the client assertion
+({{AudienceInjectionCountermeasuresTargetEP}}) as an audience value, for
+example, to force its clients to adopt the respective countermeasure.
 
 
 ## Cross-toolkit OAuth Account Takeover {#COAT}

--- a/draft-ietf-oauth-security-topics-update.md
+++ b/draft-ietf-oauth-security-topics-update.md
@@ -633,6 +633,13 @@ for their valuable feedback and contributions to this document.
 
 [[ To be removed from the final specification ]]
 
+-02
+
+* Simplify core attack description for Audience Injection attacks by moving "why token EP" discussion to a new section
+* Include concrete examples for how an attacker may misuse client assertions obtained via Audience Injection attacks
+* Add implementation considerations for Audience Injection countermeasures, including recommendations for how to deal with ASs that only accept their token endpoint as audience value
+
+
 -01
 
 * Clarify that shared redirection URI is not a precondition of COAT

--- a/draft-ietf-oauth-security-topics-update.md
+++ b/draft-ietf-oauth-security-topics-update.md
@@ -394,17 +394,20 @@ authorization server, audience injection attacks are possible.
 Therefore, audience injection attacks need to be prevented by the
 client.
 
-Note that the following countermeasures mandate the use of single
-audience value (as opposed to multiple audiences in array). This is because {{Section 4.1.3
-of ?RFC7519}} allows the receiver of an audience-restricted JWT to
-accept the JWT even if the receiver identifies with only one of the
-values in such an array.
-
 Clients that interact with more than one authorization server and
 authenticate with signature-based client authentication methods MUST
 employ one of the following countermeasures, unless audience injection
 attacks are mitigated by other means, such as using fresh key material
 for each authorization server.
+
+The countermeasures described below mandate the use of single audience
+value (as opposed to multiple audiences in an array).  This is because
+{{Section 4.1.3 of ?RFC7519}} allows the receiver of an
+audience-restricted JWT to accept the JWT even if the receiver
+identifies with only one of the values in such an array.  Since the
+countermeasures rely on the client using an unambiguous audience value,
+there is no value in including additional ones (that would need to be
+unambiguous as well).
 
 Note that the countermeasures described in
 {{AudienceInjectionCountermeasuresASissuer}} and


### PR DESCRIPTION
- Make the core attack description easier to follow by moving "why token EP" discussion to a new subsection
- Include two (Phase II) attack examples directly in the attack description instead of just pointing to the paper
- Discuss how clients can deal with ASs that only accept their token EP as `aud`