### PR TITLE
Add CUHK abbreviation for Kaixuan Luo's affiliation

### DIFF
--- a/draft-ietf-oauth-security-topics-update.md
+++ b/draft-ietf-oauth-security-topics-update.md
@@ -40,6 +40,7 @@ author:
  -
     fullname: "Kaixuan Luo"
     organization: The Chinese University of Hong Kong
+    abbrev: CUHK
     email: kaixuan@ie.cuhk.edu.hk
     region: Hong Kong
     country: China


### PR DESCRIPTION
## Summary

- Add `abbrev: CUHK` for The Chinese University of Hong Kong in the author metadata

resolves the I-D checklist error in #57 
